### PR TITLE
Add more information when crashing due to bad cell record

### DIFF
--- a/FSQCellManifest.podspec
+++ b/FSQCellManifest.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name      = 'FSQCellManifest'
-  s.version   = '1.3.1'
+  s.version   = '1.3.2'
   s.platform  = :ios, '8.0'
   s.summary   = 'A UITableView and UICollectionView delegate and datasource that provides a simpler unified interface for describing your sections and cells.'
   s.homepage  = 'https://github.com/foursquare/FSQCellManifest'

--- a/FSQCellManifest/FSQCellManifest.m
+++ b/FSQCellManifest/FSQCellManifest.m
@@ -1551,13 +1551,27 @@ typedef NS_ENUM(NSInteger, FSQCellRecordType) {
         FSQCellRecord *record = [self cellRecordAtIndexPath:indexPath];
         NSString *identifier = record.reuseIdentifier ?: NSStringFromClass(record.cellClass);
         
-        if (!record || !identifier || !record.cellClass) {
+        if (!record) {
             @throw ([NSException exceptionWithName:kFSQIdentifierClassMismatchException
                                             reason:@"Attempting to initialize call with a bad or nil FSQCellRecord"
                                           userInfo:nil]);
             return nil;
         }
-        
+
+        if (!identifier) {
+            @throw ([NSException exceptionWithName:kFSQIdentifierClassMismatchException
+                                            reason:@"Attempting to initialize call with a bad or nil identifier"
+                                          userInfo:nil]);
+            return nil;
+        }
+
+        if (!record.cellClass) {
+            @throw ([NSException exceptionWithName:kFSQIdentifierClassMismatchException
+                                            reason:@"Attempting to initialize call with a bad or nil FSQCellRecord cellClass"
+                                          userInfo:nil]);
+            return nil;
+        }
+
         [self registerIdentifier:identifier forCellClass:record.cellClass recordType:FSQCellRecordTypeBody];
         
         UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:identifier forIndexPath:indexPath];

--- a/FSQCellManifest/FSQCellManifest.m
+++ b/FSQCellManifest/FSQCellManifest.m
@@ -1564,12 +1564,17 @@ typedef NS_ENUM(NSInteger, FSQCellRecordType) {
             if (!record) {
                 badOrNilObject = @"FSQCellRecord";
             }
-            else if (!identifier) {
-                badOrNilObject = @"identifier";
+            if (!identifier) {
+                if (badOrNilObject.length > 0) {
+                    badOrNilObject = [badOrNilObject stringByAppendingString:@" and "];
+                }
+                badOrNilObject = [badOrNilObject stringByAppendingString:@"identifier"];
             }
-            else {
-                //record.cellClass
-                badOrNilObject = @"FSQCellRecord.cellClass";
+            if (!record.cellClass) {
+                if (badOrNilObject.length > 0) {
+                    badOrNilObject = [badOrNilObject stringByAppendingString:@" and "];
+                }
+                badOrNilObject = [badOrNilObject stringByAppendingString:@"FSQCellRecord.cellClass"];
             }
             NSString *reasonFormatter = @"Attempting to initialize call with a bad or nil %@ in class: %@ with %@ and %@";
 

--- a/FSQCellManifest/FSQCellManifest.m
+++ b/FSQCellManifest/FSQCellManifest.m
@@ -1551,25 +1551,39 @@ typedef NS_ENUM(NSInteger, FSQCellRecordType) {
         FSQCellRecord *record = [self cellRecordAtIndexPath:indexPath];
         NSString *identifier = record.reuseIdentifier ?: NSStringFromClass(record.cellClass);
         
-        if (!record) {
-            @throw ([NSException exceptionWithName:kFSQIdentifierClassMismatchException
-                                            reason:@"Attempting to initialize call with a bad or nil FSQCellRecord"
-                                          userInfo:nil]);
-            return nil;
-        }
+        if (!record || !identifier || !record.cellClass) {
+            NSString *delegateClassName = NSStringFromClass([self.delegate class]) ?: @"";
+            NSString *indexPathString = [NSString stringWithFormat:@"indexPath.section: %@, indexPath.row: %@",
+                                         @(indexPath.section),
+                                         @(indexPath.row)];
+            NSString *tablePathString = [NSString stringWithFormat:@"tableView.numberOfSections: %@, [tableView numberOfRowsInSection:indexPath.section]: %@",
+                                         @(tableView.numberOfSections),
+                                         @([tableView numberOfRowsInSection:indexPath.section])];
 
-        if (!identifier) {
-            @throw ([NSException exceptionWithName:kFSQIdentifierClassMismatchException
-                                            reason:@"Attempting to initialize call with a bad or nil identifier"
-                                          userInfo:nil]);
-            return nil;
-        }
+            NSString *badOrNilObject = @"";
+            if (!record) {
+                badOrNilObject = @"FSQCellRecord";
+            }
+            else if (!identifier) {
+                badOrNilObject = @"identifier";
+            }
+            else {
+                //record.cellClass
+                badOrNilObject = @"FSQCellRecord.cellClass";
+            }
+            NSString *reasonFormatter = @"Attempting to initialize call with a bad or nil %@ in class: %@ with %@ and %@";
 
-        if (!record.cellClass) {
+            NSString *reason = [NSString stringWithFormat:reasonFormatter,
+                                badOrNilObject,
+                                delegateClassName,
+                                indexPathString,
+                                tablePathString];
+
             @throw ([NSException exceptionWithName:kFSQIdentifierClassMismatchException
-                                            reason:@"Attempting to initialize call with a bad or nil FSQCellRecord cellClass"
+                                            reason:reason
                                           userInfo:nil]);
             return nil;
+
         }
 
         [self registerIdentifier:identifier forCellClass:record.cellClass recordType:FSQCellRecordTypeBody];


### PR DESCRIPTION
When an exception is thrown due to a bad or nil: cell record, identifier, or record's cell class there isn't much information that's useful for debugging.

Adding information:
1. Which reason (of bad or nil: cell record, identifier, or record's cell class) is the exception thrown.
2. What is the delegate's class.
3. What indexPath is trying to be accessed.
